### PR TITLE
Renaming models to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ And then you can use it.
 
 ## Props
 
-* **models:** Required
+* **options:** Required
 
 ``` javascript
-var models = {
+var options = {
 	key1: {
 		label: 'label1',
 		xx: {},
@@ -39,11 +39,11 @@ var models = {
 
 ```
 
-> models is the structrue to pass to the PickerIOS and Picker. So the structure is kind of similar to PickerIOS. You need to pass an object with sorts of keys to identify the options. And in each of the key object, one field is nessarrary, it is 'label'. The 'label' is the word of the option you want to show and the others are content of this option.
+> options is the structrue to pass to the PickerIOS and Picker. So the structure is kind of similar to PickerIOS. You need to pass an object with sorts of keys to identify the options. And in each of the key object, one field is nessarrary, it is 'label'. The 'label' is the word of the option you want to show and the others are content of this option.
 
 * **selectedKey:** Optional
 
-> **selectedKey** is the one of the key in models representing the default option.If you don\`t use this prop, the default option is nothing.
+> **selectedKey** is the one of the key in options representing the default option.If you don\`t use this prop, the default option is nothing.
 
 * **onChange:<Function>** Required
 
@@ -106,4 +106,3 @@ class AwesomeProject extends Component {
 }
 
 ```
-

--- a/index.js
+++ b/index.js
@@ -41,23 +41,23 @@ export default class Select extends React.Component {
   }
 
   _renderAndroid() {
-    const { models, selectedKey, onChange, style, labelStyle, ...other } = this.props;
+    const { options=this.props.models, selectedKey, onChange, style, labelStyle, ...other } = this.props;
 
     return (
       <View style={[styles.selectContainer, style]} {...other}>
         <Text style={labelStyle} >
-          {models[this.state.selectedKey] ? models[this.state.selectedKey].label : ""}
+          {options[this.state.selectedKey] ? options[this.state.selectedKey].label : ""}
         </Text>
         <Picker
           selectedValue={this.state.selectedKey ? this.state.selectedKey : ""}
           onValueChange={this._onChange.bind(this)}
           style={[styles.androidPicker]}
         >
-          {Object.keys(models).map((key) => (
+          {Object.keys(options).map((key) => (
             <Picker.Item
               key={key}
               value={key}
-              label={models[key].label}
+              label={options[key].label}
             />
           ))}
         </Picker>
@@ -67,7 +67,7 @@ export default class Select extends React.Component {
   }
 
   _renderIOS() {
-    const { models, selectedKey, onChange, style, labelStyle, ...other } = this.props;
+    const { options=this.props.models, selectedKey, onChange, style, labelStyle, ...other } = this.props;
     var modalBackgroundStyle = {
       backgroundColor: 'transparent',
     };
@@ -75,7 +75,7 @@ export default class Select extends React.Component {
     return (
       <View style={[styles.selectContainer, style]} {...other}>
         <Text style={labelStyle} onPress={this._setModalVisible.bind(this, true)}>
-          {models[this.state.selectedKey] ? models[this.state.selectedKey].label : ""}
+          {options[this.state.selectedKey] ? options[this.state.selectedKey].label : ""}
         </Text>
         <Modal
           animationType="slide"
@@ -94,11 +94,11 @@ export default class Select extends React.Component {
                                onValueChange={this._onChange.bind(this)}
                                style={styles.pickerIOS}
                     >
-                      {Object.keys(models).map((key) => (
+                      {Object.keys(options).map((key) => (
                         <Picker.Item
                           key={key}
                           value={key}
-                          label={models[key].label}
+                          label={options[key].label}
                         />
                       ))}
                     </Picker>
@@ -117,7 +117,7 @@ export default class Select extends React.Component {
 }
 
 Select.propTypes = {
-  models: React.PropTypes.object,
+  options: React.PropTypes.object,
   selectedKey: React.PropTypes.string,
   style: React.PropTypes.object,
   labelStyle: React.PropTypes.object,


### PR DESCRIPTION
Name change prop that takes the select items, options feels more natural than models.

Using models as prop still work so it's backwards compatible.
