### PR TITLE
Refactoring proptypes for StyleSheet

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,8 +119,7 @@ export default class Select extends React.Component {
 Select.propTypes = {
   models: React.PropTypes.object,
   selectedKey: React.PropTypes.string,
-  style: React.PropTypes.object,
-  labelStyle: React.PropTypes.object,
+  labelStyle: Text.propTypes.style,
   onChange: React.PropTypes.func
 };
 


### PR DESCRIPTION
When using this component with [`StyleSheet.create`](https://facebook.github.io/react-native/docs/stylesheet.html) React throws warnings because `StyleSheet` uses numbers.

Reading up on this, using [this approach](https://github.com/facebook/react-native/pull/6750#issuecomment-204078939) is recommended.
